### PR TITLE
ci: add GitHub Actions CI + automated GitHub Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -15,3 +15,35 @@ $ pnpm dev
 $ pnpm build
 $ pnpm preview
 ```
+
+## Deployment
+
+Deployment is automated. Merging to `master` triggers the
+[Deploy to GitHub Pages](.github/workflows/deploy.yml) workflow, which builds
+the site and publishes it to GitHub Pages via GitHub Actions.
+
+**Do not hand-build or commit the `docs/` output.** The workflow rebuilds it on
+every push to `master`.
+
+Every pull request also runs [CI](.github/workflows/ci.yml) (`pnpm build`, which
+includes `vue-tsc` type checking) as a required gate.
+
+### One-time maintainer step
+
+The automated deploy publishes through the **GitHub Actions** Pages source, but
+the repo is still configured for the legacy "deploy from a branch" (`/docs`)
+source. A maintainer must flip it once, in **Settings → Pages → Build and
+deployment → Source → GitHub Actions**, or via the API:
+
+``` bash
+gh api -X PUT repos/less/less-preview/pages -f build_type=workflow
+```
+
+Until that flip happens the committed `docs/` folder is left in place so the
+live site keeps serving. Once the flip is done and a deploy has gone green, a
+follow-up change should stop tracking build output:
+
+``` bash
+echo "docs/" >> .gitignore
+git rm -r --cached docs
+```


### PR DESCRIPTION
Adds CI and automated deployment; retires the hand-committed `docs/` publishing step.

## What this does

### 1. `.github/workflows/ci.yml` — PR gate
Runs on every `pull_request` and on `push` to `master`: checkout → `pnpm/action-setup@v4` (pnpm 9, matching `pnpm-lock.yaml` v9.0) → `actions/setup-node@v4` (node 20, `cache: pnpm`) → `pnpm install --frozen-lockfile` → `pnpm build`. Because `build` is `vue-tsc --noEmit && vite build`, this catches both type errors and build breakage. All action versions pinned.

### 2. `.github/workflows/deploy.yml` — automated deploy
On `push` to `master`, builds and publishes to GitHub Pages through the **GitHub Actions Pages** path — `actions/configure-pages@v5` → `actions/upload-pages-artifact@v3` (path `docs`) → `actions/deploy-pages@v4` — with `permissions: { contents: read, pages: write, id-token: write }` and `environment: github-pages`. This removes the need to hand-build and commit `docs/`.

### 3. One-time maintainer step (required to activate deploy)
The repo Pages source is currently **legacy** (`build_type: legacy`, deploy from `master` `/docs`). The Actions deploy needs the source set to **GitHub Actions**. This was deliberately **not** flipped from the automation side: flipping it before any Actions deployment exists would take the legacy `/docs` source offline and the live site would 404. It must be flipped so it coincides with the first green deploy on `master`.

Maintainer, after merge (or just before): **Settings → Pages → Build and deployment → Source → GitHub Actions**, or:
```
gh api -X PUT repos/less/less-preview/pages -f build_type=workflow
```

### 4. `docs/` still tracked (intentional, for now)
To avoid the site going dark, this PR leaves the committed `docs/` in place — the legacy source keeps serving until the flip above lands and a deploy goes green. **Follow-up once Actions Pages is live:**
```
echo "docs/" >> .gitignore
git rm -r --cached docs
```
The README documents this.

## Verification
`pnpm@9 install --frozen-lockfile && pnpm build` runs green locally (vue-tsc typecheck + vite build, 119 modules). The CI workflow runs on this PR — see the checks below.

## Interaction with #28
#28 (`fix/switcher-default-stable`) rebuilds and commits `docs/`. That is fine and still correct while the legacy source is live. Once this lands and the Pages source is flipped to GitHub Actions, hand-committed `docs/` becomes obsolete and the follow-up above removes it. Merge order between the two does not matter; only text-level conflicts in `docs/` are possible, resolvable by taking either build (the deploy workflow rebuilds regardless).