### PR TITLE
feat: opt-in Less v5 alpha (experimental) in the version switcher

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -34,6 +34,14 @@ async function fetchVersions() {
     majorMinorSet.add(majorMinor);
     return true
   });
+  // Opt-in: surface the latest v5 alpha (npm `alpha` dist-tag). It loads the
+  // dev browser bundle (dist/less-browser-dev.js, window.less) — see fetchLess.
+  // Alphas published before that file existed will 404 and show the load tip.
+  // Kept out of the default so stable (`latest`) stays the landing version.
+  const alpha = data.tags?.alpha;
+  if (alpha && !publishedVersions.includes(alpha)) {
+    publishedVersions.unshift(alpha);
+  }
   // Default to the npm `latest` dist-tag (stable, currently 4.x), never a prerelease.
   const latest = data.tags?.latest;
   const defaultVersion = (latest && publishedVersions.includes(latest))
@@ -49,7 +57,12 @@ async function fetchVersions() {
 
 function fetchLess() {
   emit("upLoadingLessJS");
-  const url = baseVersionUrl + activeVersion;
+  // v5 alpha (any prerelease) ships only a Node/CJS default entry; a browser
+  // <script> must load the dedicated dev bundle instead. Stable 4.x loads its
+  // normal UMD entry. Both define window.less with the same render API.
+  const url = activeVersion.includes("-")
+    ? `${baseVersionUrl}${activeVersion}/dist/less-browser-dev.js`
+    : baseVersionUrl + activeVersion;
   let firstLoad = false;
   const scriptDom = document.getElementById("lessScript");
   if (scriptDom) {
@@ -138,11 +151,11 @@ init();
         -->
         <div class="version-select-click" @click.stop @click="toggle">
           <span class="active-version">
-            {{ activeVersion }}
+            {{ activeVersion }}{{ activeVersion.includes("-") ? " (experimental)" : "" }}
           </span>
           <ul v-if="expanded" class="versions">
             <li v-for="(item, index) in publishedVersions" :key="index">
-              <a @click="setLessVersion(item)">{{ item }}</a>
+              <a @click="setLessVersion(item)">{{ item }}{{ item.includes("-") ? " (experimental)" : "" }}</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Surfaces the npm `alpha` dist-tag as a labeled **"(experimental)"** entry at the top of the version switcher. Stable `latest` stays the default.

A prerelease loads the dedicated dev browser bundle — `https://cdn.jsdelivr.net/npm/less@<version>/dist/less-browser-dev.js` — instead of the Node-only default entry that a browser `<script>` cannot execute. That bundle defines `window.less` with the same `render(input, options, callback)` API as 4.x, so the compile path in `App.vue` is unchanged.

Alphas published before that file existed (≤ `5.0.0-alpha.2`) 404 and show the existing load-fail tip without bricking the page; it lights up on the next alpha publish (less/less.js#4516, #4519).

Verified locally in a browser: 4.x still compiles the sample; the alpha entry appears and, pointed at a locally-built bundle, compiles through the unchanged `updateVue` path.