### PR TITLE
feat: only offer a Less alpha that ships the browser bundle

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import axios from "axios";
+import { atLeast } from "../options";
 import Select from "./Select.vue";
 const props = defineProps(["store"]);
 const { store } = props;
 
 const baseVersionUrl = "https://cdn.jsdelivr.net/npm/less@";
+// First Less alpha whose npm package includes dist/less-browser-dev.js.
+const MIN_BROWSER_BUNDLE_ALPHA = "5.0.0-alpha.3";
 let activeVersion = $ref("");
 let publishedVersions = $ref<string[]>();
 let showTipFlag = $ref(false);
@@ -40,10 +43,11 @@ async function fetchVersions() {
   });
   // Opt-in: surface the latest v5 alpha (npm `alpha` dist-tag). It loads the
   // dev browser bundle (dist/less-browser-dev.js, window.less) — see fetchLess.
-  // Alphas published before that file existed will 404 and show the load tip.
+  // Like the Less benchmark runner's per-file minimum versions, only offer an
+  // alpha that actually ships that file; older alphas would just 404.
   // Kept out of the default so stable (`latest`) stays the landing version.
   const alpha = data.tags?.alpha;
-  if (alpha && !publishedVersions.includes(alpha)) {
+  if (alpha && atLeast(alpha, MIN_BROWSER_BUNDLE_ALPHA) && !publishedVersions.includes(alpha)) {
     publishedVersions.unshift(alpha);
   }
   // Default to the npm `latest` dist-tag (stable, currently 4.x), never a prerelease.

--- a/src/options.ts
+++ b/src/options.ts
@@ -40,10 +40,11 @@ const all: OptionDescriptor[] = [
 ]
 
 // Numeric core only: "5.0.0-alpha.2" compares as 5.0.0; "4.x" as 4.0.0.
+// (Option gates are keyed on the release line, so an alpha counts as its release.)
 const parse = (v: string) =>
   v.split('-')[0].split('.').map(p => Number(p) || 0)
 
-const compare = (a: string, b: string) => {
+export const compare = (a: string, b: string) => {
   const [x, y] = [parse(a), parse(b)]
   for (let i = 0; i < 3; i++) {
     if ((x[i] ?? 0) !== (y[i] ?? 0)) return (x[i] ?? 0) - (y[i] ?? 0)
@@ -60,3 +61,11 @@ export const supportedOptions = (version: string) =>
 // The only object that reaches less.render: valid keys for `version`, nothing else.
 export const renderOptions = (store: OptionStore, version: string) =>
   Object.fromEntries(supportedOptions(version).map(o => [o.key, store[o.key]]))
+
+// Prerelease-aware: same numeric core, then the prerelease number
+// ("5.0.0-alpha.3" >= "5.0.0-alpha.3"; "5.0.0-alpha.2" < "5.0.0-alpha.3").
+const prereleaseNumber = (v: string) => v.includes('-') ? Number(v.split('-')[1].split('.').pop()) || 0 : Infinity
+export const atLeast = (v: string, min: string) => {
+  const core = compare(v, min)
+  return core !== 0 ? core > 0 : prereleaseNumber(v) >= prereleaseNumber(min)
+}


### PR DESCRIPTION
The experimental alpha entry loads `dist/less-browser-dev.js` from jsDelivr. Alphas published before `5.0.0-alpha.3` do not include that file, so selecting them only produced a load failure.

This gates the entry on the first alpha that ships the bundle. The existing option gates compare the numeric release core only (an alpha counts as its release line), so a small prerelease-aware `atLeast` is added for this one check: `5.0.0-alpha.2` is excluded, `5.0.0-alpha.3`, later alphas and the `5.0.0` release are included.

Same idea as the Less benchmark runner's per-file minimum versions: only offer what the selected version can actually run.