### PR TITLE
fix: left-align switch labels; shorten the deprecated minify label

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -157,6 +157,10 @@ body {
     padding: 0;
     font: inherit;
     color: @muted;
+    text-align: left;
+    > span:first-child {
+      flex: 1;
+    }
     cursor: pointer;
     &:focus-visible .switch-track {
       outline: 2px solid @accent;

--- a/src/options.ts
+++ b/src/options.ts
@@ -36,7 +36,7 @@ const all: OptionDescriptor[] = [
   { key: 'strictUnits', label: 'Strict units', type: 'switch', max: '5.0.0' },
   { key: 'unitMode', label: 'Unit mode', type: 'select', values: ['loose', 'strict', 'preserve'], min: '5.0.0' },
   { key: 'collapseNesting', label: 'Collapse nesting', type: 'switch', min: '5.0.0' },
-  { key: 'compress', label: 'Minify output (deprecated)', type: 'switch', max: '5.0.0' }
+  { key: 'compress', label: 'Minify (deprecated)', type: 'switch', max: '5.0.0' }
 ]
 
 // Numeric core only: "5.0.0-alpha.2" compares as 5.0.0; "4.x" as 4.0.0.


### PR DESCRIPTION
The option switches are buttons, so a label long enough to wrap ("Minify output (deprecated)" on 4.x) centered its second line under the switch track, which read as a stray indent in the sidebar. The label is now left-aligned and takes the row's width, and the minify label is shortened to "Minify (deprecated)" so it fits on one line.